### PR TITLE
update haskell-gi-base to 0.14 for tests

### DIFF
--- a/jsaddle.cabal
+++ b/jsaddle.cabal
@@ -61,7 +61,7 @@ test-suite test-tool
         buildable: False
     else
         build-depends:
-            haskell-gi-base >= 0.13 && < 0.14,
+            haskell-gi-base >= 0.14 && < 0.15,
             gi-glib >=0.2.44 && <0.2.49,
             gi-gtk >=0.3.16 && <0.3.21,
             gi-webkit >=0.2.4 && <0.2.5,


### PR DESCRIPTION
Looks like the test dependancies were forgotten
